### PR TITLE
Add behaviour as an ordered attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ def some_function(_),
 * Reference other modules in the following order:
 
     1. `@moduledoc`
+    1. `@behaviour`
     1. `use`
     1. `import`
     1. `alias`
@@ -524,6 +525,8 @@ def some_function(_),
     @moduledoc """
     An example module
     """
+
+    @behaviour MyBehaviour
 
     use GenServer
     import Something


### PR DESCRIPTION
It seemed worthwhile to separate the `@behaviour` attribute from other module attributes. I wasn't sure where it made the most sense to put it. I settled on under the `@moduledoc` and above imports. 