### PR TITLE
Remove generic advice about comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,13 +446,6 @@ def some_function(_),
   String.upcase(some_string) # Capitalize string.
   ```
 
-* Keep existing comments up-to-date.
-  An outdated comment is worse than no comment at all.
-
-* Avoid writing comments to explain bad code.
-  Refactor the code to make it self-explanatory.
-  ("Do — or do not — there is no try." —Yoda)
-
 #### Comment Annotations
 
 * Annotations should usually be written on the line immediately above the


### PR DESCRIPTION
These are common to good coding practices, not specific to Elixir.

I think it's better to remove them to keep the guide focused and concise.