### PR TITLE
use parentheses for zero arity function calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,22 @@ def some_function(_),
   end
   ```
 
+* Use parentheses for calls to function with a zero arity so they can be destinguished from variables.
+
+  ```elixir
+  defp do_stuff, do: ...
+  
+  # not preferred
+  def my_func do
+    do_stuff # is this a variable or a function call
+  end
+  
+  # preferred
+  def my_func do
+    do_stuff() # this is clearly a function call
+  end
+  ```
+
 
 ### Naming
 


### PR DESCRIPTION
Zero arity functions should be invoked using parentheses to distinguish them from variables. The benefits are great, as a function call is a way more complex part of a program than using a variable so I believe it's important that those calls can not be mistaken for simple variables. 

In a future version of Elixir not doing this will produce a compiler warning, so I think it's oblivious that this is also the opinion of the core team.

Source: Andrea Leopardi (@whatyouhide) on the ElixirFountain at 24:30 (I am trying to find a better source)