### PR TITLE
Improve struct and defstruct guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     * [Modules](#modules)
     * [Documentation](#documentation)
     * [Typespecs](#typespecs)
+    * [Structs](#structs)
     * [Exceptions](#exceptions)
     * _Collections_
     * [Strings](#strings)
@@ -739,6 +740,18 @@ directives (see [Modules](#modules)).
   end
   ```
 
+
+### Structs
+
+* If all the struct's fields default to nil, supply them as a list of atoms.
+
+  ```elixir
+  # not preferred
+  defstruct name: nil, params: nil
+
+  # preferred
+  defstruct [:name, :params]
+  ```
 
 ### Exceptions
 

--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ def some_function(_),
     1. `import`
     1. `alias`
     1. `require`
+    1. `defstruct`
     1. `@type`
     1. `@module_attribute`
 
@@ -568,6 +569,8 @@ def some_function(_),
     alias My.Long.Module.Name
     alias My.Other.Module.Name
     require Integer
+
+    defstruct name: nil, params: []
 
     @type params :: [{binary, binary}]
 

--- a/README.md
+++ b/README.md
@@ -730,6 +730,18 @@ directives (see [Modules](#modules)).
                          | a_final_type
   ```
 
+* Name the main type for a module `t`, for example: the type specification for a
+  struct.
+
+  ```elixir
+  defstruct name: nil, params: []
+
+  @type t :: %__MODULE__{
+    name: String.t,
+    params: Keyword.t
+  }
+  ```
+
 * Place specifications right before the function definition,
   separated by a newline.
 


### PR DESCRIPTION
Adds a new section for structs, and also addresses issues #95 and #106.

I've seen the `defstruct` put either before or after the types. I recommend putting it after for a couple reasons:

* the type for the struct is easiest to understand when placed last in the list of types, since it will likely use more basic types already defined; if it's placed last, then you can place the `defstruct` right after it.
* `defstruct` seems closer to `def` than `use` or `alias`, hence, put it lower

What does everyone think?